### PR TITLE
EP3 - Booking service Part I

### DIFF
--- a/.graphqlconfig.yml
+++ b/.graphqlconfig.yml
@@ -10,7 +10,7 @@ projects:
         codeGenTarget: javascript
         generatedFileName: ''
         docsFilePath: src/graphql
-        graphQLApiId: p3jpzjnkcjfnnjs2qcd7rafkum
+        graphQLApiId: 2pa2xn3qzzdi7ntbhdozirkmiy
       endpoints:
         prod: >-
-          https://2byom2uph5gpzixmozba5rdsky.appsync-api.eu-west-1.amazonaws.com/graphql
+          https://wl7p3r2svrbgjb23kgjyx73yzu.appsync-api.eu-west-1.amazonaws.com/graphql

--- a/.graphqlconfig.yml
+++ b/.graphqlconfig.yml
@@ -11,6 +11,3 @@ projects:
         generatedFileName: ''
         docsFilePath: src/graphql
         graphQLApiId: 2pa2xn3qzzdi7ntbhdozirkmiy
-      endpoints:
-        prod: >-
-          https://wl7p3r2svrbgjb23kgjyx73yzu.appsync-api.eu-west-1.amazonaws.com/graphql

--- a/amplify/backend/api/awsserverlessairline/parameters.json
+++ b/amplify/backend/api/awsserverlessairline/parameters.json
@@ -6,5 +6,7 @@
             "authcognitoa7d29d9d",
             "Outputs.UserPoolId"
         ]
-    }
+    },
+    "FlightDataSource": "FlightTable",
+    "BookingDataSource": "BookingTable"
 }

--- a/amplify/backend/api/awsserverlessairline/parameters.json
+++ b/amplify/backend/api/awsserverlessairline/parameters.json
@@ -3,7 +3,7 @@
     "DynamoDBBillingMode": "PAY_PER_REQUEST",
     "AuthCognitoUserPoolId": {
         "Fn::GetAtt": [
-            "authserverlessaairlineauth",
+            "authcognitoa7d29d9d",
             "Outputs.UserPoolId"
         ]
     }

--- a/amplify/backend/api/awsserverlessairline/schema.graphql
+++ b/amplify/backend/api/awsserverlessairline/schema.graphql
@@ -18,7 +18,7 @@ type Flight @model {
 }
 
 type Booking @model @auth(rules: [
-      {allow: owner, ownerField: "customer", identityField: "sub"},
+      {allow: owner, ownerField: "customer", identityField: "sub", operations: [read, update]},
       {allow: groups, groups: ["Admin"]}
     ]) {
     id: ID!

--- a/amplify/backend/api/awsserverlessairline/schema.graphql
+++ b/amplify/backend/api/awsserverlessairline/schema.graphql
@@ -35,3 +35,17 @@ enum BookingStatus {
     CONFIRMED
     CANCELLED
 }
+
+input CreateBookingInput {
+  id: ID
+  status: BookingStatus
+  paymentToken: String!
+  checkedIn: Boolean
+  customer: String
+  bookingInboundFlightId: ID
+  bookingOutboundFlightId: ID!
+}
+
+type Mutation {
+    processBooking(input: CreateBookingInput!): Booking
+}

--- a/amplify/backend/api/awsserverlessairline/schema.graphql
+++ b/amplify/backend/api/awsserverlessairline/schema.graphql
@@ -14,4 +14,24 @@ type Flight @model {
     ticketPrice: Int!
     ticketCurrency: String!
     flightNumber: Int!
+    seatAllocation: Int!
+}
+
+type Booking @model @auth(rules: [
+      {allow: owner, ownerField: "customer", identityField: "sub"},
+      {allow: groups, groups: ["Admin"]}
+    ]) {
+    id: ID!
+    status: BookingStatus!
+    inboundFlight: Flight @connection 
+    outboundFlight: Flight! @connection
+    paymentToken: String!
+    checkedIn: Boolean
+    customer: String
+}
+
+enum BookingStatus {
+    UNCONFIRMED
+    CONFIRMED
+    CANCELLED
 }

--- a/amplify/backend/api/awsserverlessairline/stacks/CustomResources.json
+++ b/amplify/backend/api/awsserverlessairline/stacks/CustomResources.json
@@ -24,12 +24,118 @@
 		"S3DeploymentRootKey": {
 			"Type": "String",
 			"Description": "An S3 key relative to the S3DeploymentBucket that points to the root\nof the deployment directory."
+		},
+		"FlightDataSource": {
+			"Type": "String",
+			"Description": "Flight Data Source Name",
+			"Default": "FlightTable"
+		},
+		"BookingDataSource": {
+			"Type": "String",
+			"Description": "Booking Data Source Name",
+			"Default": "BookingTable"
 		}
 	},
 	"Resources": {
-		"EmptyResource": {
-			"Type": "Custom::EmptyResource",
-			"Condition": "AlwaysFalse"
+		"PaymentApiDatasource": {
+			"Type": "AWS::AppSync::DataSource",
+			"Properties": {
+				"Description": "Payment API to collect, verify and refund payments",
+				"Type": "HTTP",
+				"Name": "PaymentApi",
+				"ApiId": {
+					"Ref": "AppSyncApiId"
+				},
+				"HttpConfig": {
+					"Endpoint": "https://httpbin.org"
+				}
+			}
+		},
+		"ReserveFlightFunction": {
+			"Type": "AWS::AppSync::FunctionConfiguration",
+			"Properties": {
+				"ApiId": {
+					"Ref": "AppSyncApiId"
+				},
+				"Name": "ReserveFlight",
+				"Description": "Updates Flight Table and decreases Seat Allocation for a given flight",
+				"DataSourceName": {
+					"Ref": "FlightDataSource"
+				},
+				"RequestMappingTemplate": "## Decreases Seat allocation as a mean to reserve a booking\n## while booking isn't confirmed and payment verified\n## Do fail immediately if we cannot reserve a flight\n{\n    \"version\": \"2017-02-28\",\n    \"operation\": \"UpdateItem\",\n    \"key\": {\n        \"id\": $util.dynamodb.toDynamoDBJson($ctx.stash.outboundFlightId) \n    },\n    \"update\": {\n      \"expression\": \"SET seatAllocation = seatAllocation - :dec\",\n      \"expressionValues\": {\n          \":dec\": {\"N\": \"1\"}\n      }\n    },\n    \"condition\": {\n        \"expression\": \"seatAllocation > :noSeat\",\n        \"expressionValues\": {\n            \":noSeat\": {\"N\": \"0\"}\n        }\n    }\n}\n",
+				"ResponseMappingTemplate": "## Raise a GraphQL field error in case of a datasource invocation error\n#if($ctx.error)\n    $util.error(\"No seats left....\", $ctx.error.message, $ctx.error.type)\n#end\n## Pass back the result from DynamoDB. **\n$util.toJson($ctx.result)\n",
+				"FunctionVersion": "2018-05-29"
+			}
+		},
+		"ReserveBookingFunction": {
+			"Type": "AWS::AppSync::FunctionConfiguration",
+			"Properties": {
+				"ApiId": {
+					"Ref": "AppSyncApiId"
+				},
+				"Name": "ReserveBooking",
+				"Description": "Creates a new Booking in the Booking Table with status UNCONFIRMED",
+				"DataSourceName": {
+					"Ref": "BookingDataSource"
+				},
+				"RequestMappingTemplate": "## [Start] Prepare DynamoDB PutItem Request.**\n### Add default values\n$util.qr($context.args.input.put(\"createdAt\", $util.time.nowISO8601()))\n$util.qr($context.args.input.put(\"updatedAt\", $util.time.nowISO8601()))\n$util.qr($context.args.input.put(\"__typename\", \"Booking\"))\n$util.qr($context.args.input.put(\"checkedIn\", false))\n### Add logged in customer as the value\n$util.qr($context.args.input.put(\"customer\", $ctx.identity.sub))\n$util.qr($context.args.input.put(\"status\", 'UNCONFIRMED'))\n\n## Missing outbound flight ID\n{\n  \"version\": \"2017-02-28\",\n  \"operation\": \"PutItem\",\n  \"key\": {\n      \"id\":     $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))\n  },\n  \"attributeValues\": $util.dynamodb.toMapValuesJson($context.args.input),\n  \"condition\": {\n      \"expression\": \"attribute_not_exists(#id)\",\n      \"expressionNames\": {\n          \"#id\": \"id\"\n    }\n  }\n}\n## [End] Prepare DynamoDB PutItem Request. **\n",
+				"ResponseMappingTemplate": "## Raise a GraphQL field error in case of a datasource invocation error\n#if($ctx.error)\n    $util.error($ctx.error.message, $ctx.error.type)\n    $util.error(\"Unable to reserve booking....\", $ctx.error.message, $ctx.error.type)\n#end\n## Pass back the result from DynamoDB. **\n$util.toJson($ctx.result)\n",
+				"FunctionVersion": "2018-05-29"
+			}
+		},
+		"VerifyPaymentFunction": {
+			"Type": "AWS::AppSync::FunctionConfiguration",
+			"Properties": {
+				"ApiId": {
+					"Ref": "AppSyncApiId"
+				},
+				"Name": "VerifyPayment",
+				"Description": "Verifies collected payment with flight information",
+				"DataSourceName": {
+					"Fn::GetAtt": [
+						"PaymentApiDatasource",
+						"Name"
+					]
+				},
+				"RequestMappingTemplate": "##\n## Make arbitrary HTTP GET request to HTTP Data Source, pass Authorization Cognito JWT and send Payment token as Query String\n##\n{\n  \"method\": \"GET\",\n  ## E.G. if full path is https://api.xxxxxxxxx.com/posts then resourcePath would be /posts **\n  \"resourcePath\": \"/status/200\",\n  \"params\":{\n      \"query\": {\n        \"token\": $util.toJson($ctx.stash.paymentToken)\n      },\n      \"headers\": {\n          \"Authorization\": \"$ctx.request.headers.Authorization\"\n      }\n  }\n}\n## [End] Prepare DynamoDB PutItem Request. **\n",
+				"ResponseMappingTemplate": "## Raise a GraphQL field error in case of a data source invocation error\n#if($ctx.error)\n    $util.error($ctx.error.message, $ctx.error.type)\n#end\n## Pass back the result from DynamoDB. **\n$util.toJson($ctx.result)\n",
+				"FunctionVersion": "2018-05-29"
+			}
+		},
+		"ProcessBookingResolver": {
+			"Type": "AWS::AppSync::Resolver",
+			"Properties": {
+				"ApiId": {
+					"Ref": "AppSyncApiId"
+				},
+				"TypeName": "Mutation",
+				"FieldName": "processBooking",
+				"RequestMappingTemplate": "$util.qr($ctx.stash.put(\"outboundFlightId\", $ctx.args.input.bookingOutboundFlightId))\n$util.qr($ctx.stash.put(\"paymentToken\", $ctx.args.input.paymentToken))\n$util.qr($ctx.stash.put(\"customer\", $ctx.identity.sub))\n\n{}\n",
+				"ResponseMappingTemplate": "$util.toJson($ctx.result)\n",
+				"Kind": "PIPELINE",
+				"PipelineConfig": {
+					"Functions": [
+						{
+							"Fn::GetAtt": [
+								"VerifyPaymentFunction",
+								"FunctionId"
+							]
+						},
+						{
+							"Fn::GetAtt": [
+								"ReserveFlightFunction",
+								"FunctionId"
+							]
+						},
+						{
+							"Fn::GetAtt": [
+								"ReserveBookingFunction",
+								"FunctionId"
+							]
+						}
+					]
+				}
+			}
 		}
 	},
 	"Conditions": {

--- a/amplify/backend/auth/cognitoa7d29d9d/cognitoa7d29d9d-cloudformation-template.yml
+++ b/amplify/backend/auth/cognitoa7d29d9d/cognitoa7d29d9d-cloudformation-template.yml
@@ -161,15 +161,10 @@ Resources:
           Mutable: true
         
         -
-          Name: phone_number
-          Required: true
-          Mutable: true
-        
-        -
           Name: email
           Required: true
           Mutable: true
-        
+
         -
           Name: luggage_preference
           Required: false
@@ -181,8 +176,6 @@ Resources:
           Required: false
           Mutable: true
           AttributeDataType: String
-
-        
       
       AutoVerifiedAttributes: !Ref autoVerifiedAttributes
       
@@ -210,7 +203,7 @@ Resources:
   # Depends on UserPool for ID reference
     Type: "AWS::Cognito::UserPoolClient"
     Properties:
-      ClientName: serverlessaairlineauth_app_clientWeb
+      ClientName: cognitoa7d29d9d_app_clientWeb
       
       ReadAttributes: !Ref userpoolClientReadAttributes
       WriteAttributes: !Ref userpoolClientWriteAttributes
@@ -358,7 +351,7 @@ Resources:
             - Effect: Allow
               Action:
                 - 'iam:PassRole'
-              Resource: !If [ShouldNotCreateEnvResources, 'arn:aws:iam:::role/serverlessaairlineauth_totp_lambda_role', !Join ['',['arn:aws:iam:::role/serverlessaairlineauth_totp_lambda_role', '-', !Ref env]]]
+              Resource: !If [ShouldNotCreateEnvResources, 'arn:aws:iam:::role/cognitoa7d29d9d_totp_lambda_role', !Join ['',['arn:aws:iam:::role/cognitoa7d29d9d_totp_lambda_role', '-', !Ref env]]]
   MFALambda:
   # Lambda which sets MFA config values
   # Depends on MFALambdaRole for role ARN

--- a/amplify/backend/auth/cognitoa7d29d9d/parameters.json
+++ b/amplify/backend/auth/cognitoa7d29d9d/parameters.json
@@ -1,5 +1,5 @@
 {
-    "userPoolName": "serverlessairlinecognitouserpool",
+    "userPoolName": "awsserverlessairlinea7d29d9d_userpool_a7d29d9d",
     "autoVerifiedAttributes": [
         "email"
     ],
@@ -8,9 +8,9 @@
         "SMS Text Message",
         "TOTP"
     ],
-    "roleName": "serverlessaairlineauth_sns-role",
-    "roleExternalId": "serverlessaairlineauth_role_external_id",
-    "policyName": "serverlessaairlineauth-sns-policy",
+    "roleName": "cognitoa7d29d9d_sns-role",
+    "roleExternalId": "cognitoa7d29d9d_role_external_id",
+    "policyName": "cognitoa7d29d9d-sns-policy",
     "smsAuthenticationMessage": "Your authentication code is {####}",
     "smsVerificationMessage": "Your verification code is {####}",
     "emailVerificationSubject": "Your verification code",
@@ -26,10 +26,9 @@
     "requiredAttributes": [
         "family_name",
         "given_name",
-        "phone_number",
         "email"
     ],
-    "userpoolClientName": "serverlessaairlineauth_app_client",
+    "userpoolClientName": "cognitoa7d29d9d_app_client",
     "userpoolClientGenerateSecret": true,
     "userpoolClientRefreshTokenValidity": 30,
     "userpoolClientReadAttributes": [
@@ -37,23 +36,22 @@
         "family_name",
         "given_name",
         "phone_number",
-        "preferred_username",
         "email_verified",
         "phone_number_verified",
         "custom:luggage_preference",
         "custom:meal_preference"
     ],
-    "mfaLambdaRole": "serverlessaairlineauth_totp_lambda_role",
-    "mfaLambdaLogPolicy": "serverlessaairlineauth_totp_lambda_log_policy",
-    "mfaPassRolePolicy": "serverlessaairlineauth_totp_pass_role_policy",
-    "mfaLambdaIAMPolicy": "serverlessaairlineauth_totp_lambda_iam_policy",
-    "userpoolClientLambdaRole": "serverlessaairlineauth_userpoolclient_lambda_role",
-    "userpoolClientLogPolicy": "serverlessaairlineauth_userpoolclient_lambda_log_policy",
-    "userpoolClientLambdaPolicy": "serverlessaairlineauth_userpoolclient_lambda_iam_policy",
+    "mfaLambdaRole": "cognitoa7d29d9d_totp_lambda_role",
+    "mfaLambdaLogPolicy": "cognitoa7d29d9d_totp_lambda_log_policy",
+    "mfaPassRolePolicy": "cognitoa7d29d9d_totp_pass_role_policy",
+    "mfaLambdaIAMPolicy": "cognitoa7d29d9d_totp_lambda_iam_policy",
+    "userpoolClientLambdaRole": "cognitoa7d29d9d_userpoolclient_lambda_role",
+    "userpoolClientLogPolicy": "cognitoa7d29d9d_userpoolclient_lambda_log_policy",
+    "userpoolClientLambdaPolicy": "cognitoa7d29d9d_userpoolclient_lambda_iam_policy",
     "userpoolClientSetAttributes": true,
     "useDefault": "manual",
     "authSelections": "userPoolOnly",
-    "resourceName": "serverlessaairlineauth",
+    "resourceName": "cognitoa7d29d9d",
     "userpoolClientWriteAttributes": [
         "email",
         "family_name",

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -1,6 +1,6 @@
 {
 	"auth": {
-		"serverlessaairlineauth": {
+		"cognitoa7d29d9d": {
 			"service": "Cognito",
 			"providerPlugin": "awscloudformation"
 		}

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -1,18 +1,18 @@
 {
     "twitch": {
         "awscloudformation": {
-            "AuthRoleName": "awsserverlessairline-20190424081806-authRole",
-            "UnauthRoleArn": "arn:aws:iam::231436140809:role/awsserverlessairline-20190424081806-unauthRole",
-            "AuthRoleArn": "arn:aws:iam::231436140809:role/awsserverlessairline-20190424081806-authRole",
+            "AuthRoleName": "awsserverlessairline-20190506121509-authRole",
+            "UnauthRoleArn": "arn:aws:iam::231436140809:role/awsserverlessairline-20190506121509-unauthRole",
+            "AuthRoleArn": "arn:aws:iam::231436140809:role/awsserverlessairline-20190506121509-authRole",
             "Region": "eu-west-1",
-            "DeploymentBucketName": "awsserverlessairline-20190424081806-deployment",
-            "UnauthRoleName": "awsserverlessairline-20190424081806-unauthRole",
-            "StackName": "awsserverlessairline-20190424081806",
-            "StackId": "arn:aws:cloudformation:eu-west-1:231436140809:stack/awsserverlessairline-20190424081806/2a230a80-66a4-11e9-8046-0ac6bcaf6240"
+            "DeploymentBucketName": "awsserverlessairline-20190506121509-deployment",
+            "UnauthRoleName": "awsserverlessairline-20190506121509-unauthRole",
+            "StackName": "awsserverlessairline-20190506121509",
+            "StackId": "arn:aws:cloudformation:eu-west-1:231436140809:stack/awsserverlessairline-20190506121509/35858dd0-6ff0-11e9-a363-020975c14ca0"
         },
         "categories": {
             "auth": {
-                "serverlessaairlineauth": {}
+                "cognitoa7d29d9d": {}
             }
         }
     }

--- a/sample-queries-mutations.gql
+++ b/sample-queries-mutations.gql
@@ -1,0 +1,129 @@
+## Add a bunch of flights
+### Aviation-edge Open API could come handy in here as an ETL process
+
+mutation flight1 {
+    createFlight(input:{
+        departureDate: "2019-05-08T08:00+0000",
+        departureAirportCode: "LGW",
+        departureAirportName: "London Gatwick",
+        departureCity: "London",
+        departureLocale: "Europe/London",
+        arrivalDate: "2019-05-08T10:15+0000",
+        arrivalAirportCode: "MAD",
+        arrivalAirportName: "Madrid Barajas",
+        arrivalCity: "Madrid",
+        arrivalLocale: "Europe/Madrid",
+        ticketPrice: 100,
+        ticketCurrency: "EUR",
+        flightNumber: 1830
+    }) {
+        id
+    }
+} 
+
+mutation flight2 {
+    createFlight(input:{
+        departureDate: "2019-01-16T10:30+0000",
+        departureAirportCode: "LGW",
+        departureAirportName: "London Gatwick",
+        departureCity: "London",
+        departureLocale: "Europe/London",
+        arrivalDate: "2019-01-16T12:45+0000",
+        arrivalAirportCode: "MAD",
+        arrivalAirportName: "Madrid Barajas",
+        arrivalCity: "Madrid",
+        arrivalLocale: "Europe/Madrid",
+        ticketPrice: 200,
+        ticketCurrency: "EUR",
+        flightNumber: 1813,
+        seatAllocation: 2
+    }) {
+        id
+    }
+}
+
+mutation flight3 {
+    createFlight(input:{
+        departureDate: "2019-01-16T12:00+0000",
+        departureAirportCode: "LGW",
+        departureAirportName: "London Gatwick",
+        departureCity: "London",
+        departureLocale: "Europe/London",
+        arrivalDate: "2019-01-16T14:15+0000",
+        arrivalAirportCode: "MAD",
+        arrivalAirportName: "Madrid Barajas",
+        arrivalCity: "Madrid",
+        arrivalLocale: "Europe/Madrid",
+        ticketPrice: 1000,
+        ticketCurrency: "EUR",
+        flightNumber: 1814,
+        seatAllocation: 2
+    }) {
+        id
+    }
+}
+
+mutation flight4 {
+    createFlight(input:{
+        departureDate: "2019-01-16T17:00+0000",
+        departureAirportCode: "LGW",
+        departureAirportName: "London Gatwick",
+        departureCity: "London",
+        departureLocale: "Europe/London",
+        arrivalDate: "2019-01-16T19:15+0000",
+        arrivalAirportCode: "MAD",
+        arrivalAirportName: "Madrid Barajas",
+        arrivalCity: "Madrid",
+        arrivalLocale: "Europe/Madrid",
+        ticketPrice: 500,
+        ticketCurrency: "EUR",
+        flightNumber: 1815,
+        seatAllocation: 2
+    }) {
+        id
+    }
+}
+
+## Fetch all flights leaving at 10am
+
+query {
+  listFlights(limit:2, filter: {
+    departureDate: {
+      beginsWith: "2019-01-16T10"
+    }
+  }){
+    items {
+      id,
+      departureDate
+    }
+  }
+}
+
+## Make a booking
+###
+
+mutation {
+  createBooking(input:{
+     status:UNCONFIRMED,
+     paymentToken: "adasdasd",
+     bookingOutboundFlightId: "flight-UUID-here"
+  }) {
+    id
+  }
+}
+
+## Fetch a booking
+### TODO: departureCity in mock will no longer be needed
+
+query {
+  getBooking(id:"b46baf62-f9fe-4b0b-b2e3-741f5e11589d") 
+  # selection set
+  {
+    id
+	  outboundFlight {
+	    id
+      departureDate
+    }
+  }
+}
+

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -1,6 +1,50 @@
 // eslint-disable
 // this is an auto generated file. This will be overwritten
 
+export const processBooking = `mutation ProcessBooking($input: CreateBookingInput!) {
+  processBooking(input: $input) {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
 export const createFlight = `mutation CreateFlight($input: CreateFlightInput!) {
   createFlight(input: $input) {
     id
@@ -17,6 +61,7 @@ export const createFlight = `mutation CreateFlight($input: CreateFlightInput!) {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
   }
 }
 `;
@@ -36,6 +81,7 @@ export const updateFlight = `mutation UpdateFlight($input: UpdateFlightInput!) {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
   }
 }
 `;
@@ -55,6 +101,139 @@ export const deleteFlight = `mutation DeleteFlight($input: DeleteFlightInput!) {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
+  }
+}
+`;
+export const createBooking = `mutation CreateBooking($input: CreateBookingInput!) {
+  createBooking(input: $input) {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
+export const updateBooking = `mutation UpdateBooking($input: UpdateBookingInput!) {
+  updateBooking(input: $input) {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
+export const deleteBooking = `mutation DeleteBooking($input: DeleteBookingInput!) {
+  deleteBooking(input: $input) {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
   }
 }
 `;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -17,6 +17,7 @@ export const getFlight = `query GetFlight($id: ID!) {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
   }
 }
 `;
@@ -41,6 +42,102 @@ export const listFlights = `query ListFlights(
       ticketPrice
       ticketCurrency
       flightNumber
+      seatAllocation
+    }
+    nextToken
+  }
+}
+`;
+export const getBooking = `query GetBooking($id: ID!) {
+  getBooking(id: $id) {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
+export const listBookings = `query ListBookings(
+  $filter: ModelBookingFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listBookings(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      status
+      inboundFlight {
+        id
+        departureDate
+        departureAirportCode
+        departureAirportName
+        departureCity
+        departureLocale
+        arrivalDate
+        arrivalAirportCode
+        arrivalAirportName
+        arrivalCity
+        arrivalLocale
+        ticketPrice
+        ticketCurrency
+        flightNumber
+        seatAllocation
+      }
+      outboundFlight {
+        id
+        departureDate
+        departureAirportCode
+        departureAirportName
+        departureCity
+        departureLocale
+        arrivalDate
+        arrivalAirportCode
+        arrivalAirportName
+        arrivalCity
+        arrivalLocale
+        ticketPrice
+        ticketCurrency
+        flightNumber
+        seatAllocation
+      }
+      paymentToken
+      checkedIn
+      customer
     }
     nextToken
   }

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -76,6 +76,68 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "getBooking",
+          "description" : null,
+          "args" : [ {
+            "name" : "id",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "ID",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "listBookings",
+          "description" : null,
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelBookingFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          }, {
+            "name" : "limit",
+            "description" : null,
+            "type" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          }, {
+            "name" : "nextToken",
+            "description" : null,
+            "type" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "ModelBookingConnection",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
@@ -295,6 +357,21 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "seatAllocation",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
@@ -486,6 +563,15 @@
           "defaultValue" : null
         }, {
           "name" : "flightNumber",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelIntFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "seatAllocation",
           "description" : null,
           "type" : {
             "kind" : "INPUT_OBJECT",
@@ -834,9 +920,346 @@
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
+        "name" : "Booking",
+        "description" : null,
+        "fields" : [ {
+          "name" : "id",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "ID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "status",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "BookingStatus",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "inboundFlight",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Flight",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "outboundFlight",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Flight",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "paymentToken",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "checkedIn",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "customer",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "ENUM",
+        "name" : "BookingStatus",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "UNCONFIRMED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "CONFIRMED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "CANCELLED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "possibleTypes" : null
+      }, {
+        "kind" : "SCALAR",
+        "name" : "Boolean",
+        "description" : "Built-in Boolean",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "ModelBookingConnection",
+        "description" : null,
+        "fields" : [ {
+          "name" : "items",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "OBJECT",
+              "name" : "Booking",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "nextToken",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelBookingFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelIDFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "status",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelBookingStatusFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "paymentToken",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelStringFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "checkedIn",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelBooleanFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "customer",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelStringFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "and",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelBookingFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "or",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelBookingFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "not",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelBookingFilterInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelBookingStatusFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "BookingStatus",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "BookingStatus",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelBooleanFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
         "name" : "Mutation",
         "description" : null,
         "fields" : [ {
+          "name" : "processBooking",
+          "description" : null,
+          "args" : [ {
+            "name" : "input",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "INPUT_OBJECT",
+                "name" : "CreateBookingInput",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
           "name" : "createFlight",
           "description" : null,
           "args" : [ {
@@ -908,9 +1331,161 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "createBooking",
+          "description" : null,
+          "args" : [ {
+            "name" : "input",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "INPUT_OBJECT",
+                "name" : "CreateBookingInput",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "updateBooking",
+          "description" : null,
+          "args" : [ {
+            "name" : "input",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "INPUT_OBJECT",
+                "name" : "UpdateBookingInput",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "deleteBooking",
+          "description" : null,
+          "args" : [ {
+            "name" : "input",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "INPUT_OBJECT",
+                "name" : "DeleteBookingInput",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "CreateBookingInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "status",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "BookingStatus",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "paymentToken",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "checkedIn",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "customer",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "bookingInboundFlightId",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "bookingOutboundFlightId",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "ID",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
         "enumValues" : null,
         "possibleTypes" : null
       }, {
@@ -1096,6 +1671,19 @@
             }
           },
           "defaultValue" : null
+        }, {
+          "name" : "seatAllocation",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
         } ],
         "interfaces" : null,
         "enumValues" : null,
@@ -1235,6 +1823,15 @@
             "ofType" : null
           },
           "defaultValue" : null
+        }, {
+          "name" : "seatAllocation",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Int",
+            "ofType" : null
+          },
+          "defaultValue" : null
         } ],
         "interfaces" : null,
         "enumValues" : null,
@@ -1242,6 +1839,100 @@
       }, {
         "kind" : "INPUT_OBJECT",
         "name" : "DeleteFlightInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "UpdateBookingInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "ID",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "status",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "BookingStatus",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "paymentToken",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "checkedIn",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "customer",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "bookingInboundFlightId",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "bookingOutboundFlightId",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "ID",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "DeleteBookingInput",
         "description" : null,
         "fields" : null,
         "inputFields" : [ {
@@ -1294,46 +1985,62 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "onCreateBooking",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "onUpdateBooking",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "onDeleteBooking",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Booking",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
         "enumValues" : null,
         "possibleTypes" : null
       }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelBooleanFilterInput",
+        "kind" : "ENUM",
+        "name" : "ModelSortDirection",
         "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        } ],
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "SCALAR",
-        "name" : "Boolean",
-        "description" : "Built-in Boolean",
         "fields" : null,
         "inputFields" : null,
         "interfaces" : null,
-        "enumValues" : null,
+        "enumValues" : [ {
+          "name" : "ASC",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "DESC",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
@@ -1437,25 +2144,6 @@
         "inputFields" : null,
         "interfaces" : null,
         "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "ENUM",
-        "name" : "ModelSortDirection",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : [ {
-          "name" : "ASC",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "DESC",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        } ],
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
@@ -2262,12 +2950,20 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_publish",
-        "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
-        "locations" : [ "FIELD_DEFINITION" ],
+        "name" : "aws_oidc",
+        "description" : "Tells the service this field/object has access authorized by an OIDC token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_cognito_user_pools",
+        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
         "args" : [ {
-          "name" : "subscriptions",
-          "description" : "List of subscriptions which will be published to when this mutation is called.",
+          "name" : "cognito_groups",
+          "description" : "List of cognito user pool groups which have access on this field",
           "type" : {
             "kind" : "LIST",
             "name" : null,
@@ -2283,12 +2979,29 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_cognito_user_pools",
-        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
         "args" : [ {
-          "name" : "cognito_groups",
-          "description" : "List of cognito user pool groups which have access on this field",
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_publish",
+        "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+        "locations" : [ "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "subscriptions",
+          "description" : "List of subscriptions which will be published to when this mutation is called.",
           "type" : {
             "kind" : "LIST",
             "name" : null,
@@ -2320,31 +3033,6 @@
             }
           },
           "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_oidc",
-        "description" : "Tells the service this field/object has access authorized by an OIDC token.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
-        "args" : [ {
-          "name" : "reason",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : "\"No longer supported\""
         } ],
         "onOperation" : false,
         "onFragment" : false,

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -1301,6 +1301,42 @@
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
+        "name" : "ModelBooleanFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "SCALAR",
+        "name" : "Boolean",
+        "description" : "Built-in Boolean",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
         "name" : "ModelFloatFilterInput",
         "description" : null,
         "fields" : null,
@@ -1420,42 +1456,6 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         } ],
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelBooleanFilterInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        } ],
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "SCALAR",
-        "name" : "Boolean",
-        "description" : "Built-in Boolean",
-        "fields" : null,
-        "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : null,
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
@@ -2283,6 +2283,27 @@
         "onFragment" : false,
         "onField" : false
       }, {
+        "name" : "aws_cognito_user_pools",
+        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "cognito_groups",
+          "description" : "List of cognito user pool groups which have access on this field",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_subscribe",
         "description" : "Tells the service which mutation triggers this subscription.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -2304,6 +2325,14 @@
         "onFragment" : false,
         "onField" : false
       }, {
+        "name" : "aws_oidc",
+        "description" : "Tells the service this field/object has access authorized by an OIDC token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "deprecated",
         "description" : null,
         "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
@@ -2317,6 +2346,22 @@
           },
           "defaultValue" : "\"No longer supported\""
         } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_api_key",
+        "description" : "Tells the service this field/object has access authorized by an API key.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_iam",
+        "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
         "onOperation" : false,
         "onFragment" : false,
         "onField" : false

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -17,6 +17,7 @@ export const onCreateFlight = `subscription OnCreateFlight {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
   }
 }
 `;
@@ -36,6 +37,7 @@ export const onUpdateFlight = `subscription OnUpdateFlight {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
   }
 }
 `;
@@ -55,6 +57,139 @@ export const onDeleteFlight = `subscription OnDeleteFlight {
     ticketPrice
     ticketCurrency
     flightNumber
+    seatAllocation
+  }
+}
+`;
+export const onCreateBooking = `subscription OnCreateBooking {
+  onCreateBooking {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
+export const onUpdateBooking = `subscription OnUpdateBooking {
+  onUpdateBooking {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
+  }
+}
+`;
+export const onDeleteBooking = `subscription OnDeleteBooking {
+  onDeleteBooking {
+    id
+    status
+    inboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    outboundFlight {
+      id
+      departureDate
+      departureAirportCode
+      departureAirportName
+      departureCity
+      departureLocale
+      arrivalDate
+      arrivalAirportCode
+      arrivalAirportName
+      arrivalCity
+      arrivalLocale
+      ticketPrice
+      ticketCurrency
+      flightNumber
+      seatAllocation
+    }
+    paymentToken
+    checkedIn
+    customer
   }
 }
 `;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Ep3

* **Visual Overview of what we were going to do**
* **Created Booking Type with `@auth`**
    - Talked about `Groups` and the importance of only seeing Bookings of my own (`allow: owner`)
    - Extended `Flight` type to include `seatAllocation: Int!`
    - Explained what `@connection` is for both `outboundFlight` and `inboundFlight`
* **Created a Booking through AppSync Console**
    - `Created a Flight` in case there isn't any available through `listFlights`
    - Used `Flight` ID to create a Booking (outboundFlight)
* **Listed a Booking through AppSync Console**
    - Demonstrated the benefits of `@connection` when listing a booking
* **Created a Pipeline Resolver (processBooking)**
    - Verified Payment using a mock endpoint (http://httpbin.org/status/200)
    - Reserved a Flight with DynamoDB Conditional Update
    - Created a Booking with an unconfirmed status

**Temporary recording before it goes to YouTube**

* Part 1 before the stream disconnection: https://www.twitch.tv/videos/422065812
* Part 2: https://www.twitch.tv/videos/422083017

### Resources

* [AWS AppSync Datasource CloudFormation resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-datasource.html)
* [AWS AppSync Pipeline Function CloudFormation resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html)
* [AWS AppSync Resolver CloudFormation resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html)
* [Introduction to AWS AppSync Pipeline Resolvers](https://medium.com/@dabit3/intro-to-aws-appsync-pipeline-functions-3df87ceddac1)
* [AWS AppSync Resolver Mapping Template DynamoDB UpdateItem](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-updateitem)
* [`@model` directive used for granular authorization](https://aws-amplify.github.io/docs/cli/graphql#auth)
* [**Gist with VTLs, functions, sample mutation used during episode 3**](https://gist.github.com/heitorlessa/c56c9a35ece873d8c85d709e855f378b)

---

### TODO

* [x] Automate Pipeline Resolvers via Custom Stack in Amplify CLI
* [x] Add Booking Type
* [x] Add Custom Resolver VerifyPayment
* [x] Add Custom Resolver ReserveFlight
* [x] Add Custom Resolver ReserveBooking
* [x] Add sample queries/mutations used as a separate file
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
