### PR TITLE
Hotfix - Remove python3.6 from bootstrap and SAM functions migrate to 3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ target:
 	$(info ${HELP_MESSAGE})
 	@exit 0
 
-init: ##=> Install OS deps, python3.6 and dev tools
+init: ##=> Install OS deps and dev tools
 	$(info [*] Bootstrapping CI system...)
 	@$(MAKE) _install_os_packages
 
@@ -99,10 +99,10 @@ deploy.loyalty: ##=> Deploy loyalty service using SAM and TypeScript build
 #############
 
 _install_os_packages:
-	$(info [*] Installing Python and OS deps...)
-	yum install jq python36 python36-devel python36-pip -y
-	$(info [*] Upgrading Python PIP, and installing SAM CLI and CloudFormation linter...)
-	python36 -m pip install --upgrade pip cfn-lint aws-sam-cli
+	$(info [*] Installing jq...)
+	yum install jq -y
+	$(info [*] Upgrading Python PIP, SAM CLI and CloudFormation linter...)
+	python3 -m pip install --upgrade pip cfn-lint aws-sam-cli
 
 define HELP_MESSAGE
 	Common usage:

--- a/src/backend/booking/template.yaml
+++ b/src/backend/booking/template.yaml
@@ -39,7 +39,7 @@ Resources:
     Properties:
       Handler: confirm.lambda_handler
       CodeUri: src/confirm-booking
-      Runtime: python3.6
+      Runtime: python3.7
       Environment:
         Variables:
           BOOKING_TABLE_NAME: !Ref BookingTable
@@ -52,7 +52,7 @@ Resources:
     Properties:
       Handler: cancel.lambda_handler
       CodeUri: src/cancel-booking
-      Runtime: python3.6
+      Runtime: python3.7
       Environment:
         Variables:
           BOOKING_TABLE_NAME: !Ref BookingTable
@@ -65,7 +65,7 @@ Resources:
     Properties:
       Handler: reserve.lambda_handler
       CodeUri: src/reserve-booking
-      Runtime: python3.6
+      Runtime: python3.7
       Environment:
         Variables:
           BOOKING_TABLE_NAME: !Ref BookingTable
@@ -81,7 +81,7 @@ Resources:
     Properties:
       Handler: notify.lambda_handler
       CodeUri: src/notify-booking
-      Runtime: python3.6
+      Runtime: python3.7
       Environment:
         Variables:
           BOOKING_TOPIC: !Ref BookingTopic

--- a/src/backend/catalog/template.yaml
+++ b/src/backend/catalog/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: reserve.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.7
       CodeUri: src/reserve-flight
       Timeout: 10
       Environment:
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: release.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.7
       CodeUri: src/release-flight
       Timeout: 10
       Environment:

--- a/src/backend/payment/template.yaml
+++ b/src/backend/payment/template.yaml
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: collect.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.7
       CodeUri: src/collect-payment
       Timeout: 10
       Environment:
@@ -36,7 +36,7 @@ Resources:
     Properties:
       Handler: refund.lambda_handler
       CodeUri: src/refund-payment
-      Runtime: python3.6
+      Runtime: python3.7
       Timeout: 10
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:* #24 

*Description of changes:*

Fixes current build as Amplify Console upgraded their build container to AL2 along with system python and other minor changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
