### PR TITLE
Renaming the custom metrics and Updating the log processing - async-custom-metrics to latest version

### DIFF
--- a/src/backend/booking/src/confirm-booking/confirm.py
+++ b/src/backend/booking/src/confirm-booking/confirm.py
@@ -128,7 +128,7 @@ def lambda_handler(event, context):
         logger.debug(f"Confirming booking - {booking_id}")
         ret = confirm_booking(booking_id)
 
-        log_metric(name="SuccessfulConfirmation", unit=MetricUnit.Count, value=1)
+        log_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
         logger.debug("Adding Booking Status annotation")
         tracer.put_annotation("BookingReference", ret["bookingReference"])
         tracer.put_annotation("BookingStatus", "CONFIRMED")
@@ -136,7 +136,7 @@ def lambda_handler(event, context):
         # Step Functions use the return to append `bookingReference` key into the overall output
         return ret["bookingReference"]
     except BookingConfirmationException as err:
-        log_metric(name="FailedConfirmation", unit=MetricUnit.Count, value=1)
+        log_metric(name="FailedBooking", unit=MetricUnit.Count, value=1)
         logger.debug("Adding Booking Status annotation before raising error")
         tracer.put_annotation("BookingStatus", "ERROR")
 

--- a/src/backend/log-processing/template.yaml
+++ b/src/backend/log-processing/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:374852340823:applications/async-custom-metrics
-        SemanticVersion: 1.4.0
+        SemanticVersion: 1.7.0
       Parameters:
         # What's the event source you will intend to use? If logs are pushed from CloudWatch Logs to Lambda directly, then use 'Lambda'. If logs are pushed to a Kinesis Stream first, then use 'Kinesis'. Other event sources are not supported (yet).
         EventSourceType: 'Kinesis' # Uncomment to override default value

--- a/src/backend/log-processing/template.yaml
+++ b/src/backend/log-processing/template.yaml
@@ -35,6 +35,12 @@ Resources:
         # KinesisStreamBatchSize: '100' # Uncomment to override default value
         # (optional) Timeout for the Lambda function that would ship metrics to CloudWatch. Defaults to 30s.
         # TimeoutSeconds: '30' # Uncomment to override default value
+        # (optional) Whether to report init duration for Lambda functions as metrics. Allowed values are "true" or "false".
+        # RecordLambdaColdStartMetric: 'true' # Uncomment to override default value
+        # (optional) Whether to report estimated cost for Lambda functions as metrics. Allowed values are "true" or "false".
+        # RecordLambdaCostMetric: 'true' # Uncomment to override default value
+        # (optional) Whether to collect Lambda usage metrics (i.e. billed duration, memory size,  max memory used) from the logs and turn them into metrics. Allowed values are "true" or "false".
+        # RecordLambdaUsageMetrics: 'true' # Uncomment to override default value
 
   AutoSetLogGroupsRetention:
     Type: AWS::Serverless::Application


### PR DESCRIPTION
Description of changes:
- [X] Renaming the following custom metrics
   *  _SuccessfulConfirmation_ to **SuccessfulBooking**
   * _FailedConfirmation_ to  **FailedBooking**

- [x] Updating the `async-custom-metrics` SAR app to latest version - 1.7.0
   * Update to [NodeJS 10.x runtime](https://github.com/lumigo/SAR-async-lambda-metrics/commit/63b2a4f7767d2d237370d67ae27da4ac8f43110c)
   * Also includes new parameters like RecordLambdaColdStartMetric, RecordLambdaCostMetric, RecordLambdaUsageMetrics

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
