### PR TITLE
Move 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ outputs: ##=> Fetch SAM stack outputs
 	$(MAKE) outputs.payment
 
 outputs.payment: ##=> Converts Payments output stack to Vue env variables
-	 aws cloudformation describe-stacks --stack-name $${STACK_NAME}-payment-$${AWS_BRANCH} --query 'Stacks[0].Outputs[?OutputKey==`PaymentChargeUrl`].OutputValue' | jq -r '.[] | "VUE_APP_PaymentChargeUrl" + "=\"" + (.|tostring) + "\""' >> src/frontend/.env
+	 aws cloudformation describe-stacks --stack-name $${STACK_NAME}-payment-$${AWS_BRANCH} --query 'Stacks[0].Outputs[?OutputKey==`PaymentChargeUrl`].OutputValue' | jq -r '.[] | "VUE_APP_PaymentChargeUrl" + "=\"" + (.|tostring) + "\""' > src/frontend/.env
+	 @echo "VUE_APP_StripePublicKey=\"$$STRIPE_PUBLIC_KEY\"" >> src/frontend/.env
 	 cat src/frontend/.env
-
+	 
 deploy: ##=> Deploy services
 	$(info [*] Deploying...)
 	$(MAKE) deploy.payment

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ These are the deployment steps until the full implementation is complete.:
 7) Click on `Connect app`, select `GitHub`, choose your Fork repo and select the branch **`develop`**
 8) Under "Existing Amplify backend detected", **select your new environment** created in Step 2
 9) Choose an existing Amplify Console or create a new one
-10) Lastly, expand **Environment Variables**, and add **`STRIPE_SECRET_KEY`** and its value, then conclude the installation
+10) Lastly, expand **Environment Variables**, and add **`STRIPE_SECRET_KEY`** and **`STRIPE_PUBLIC_KEY`** and its value, then conclude the installation
 
 #### Adding your first flight
 

--- a/amplify.yml
+++ b/amplify.yml
@@ -47,22 +47,22 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
-customHeaders:
-  - pattern: "**/*"
-    headers: # https://infosec.mozilla.org/guidelines/web_security
-      - key: "Strict-Transport-Security"
-        value: "max-age=31536000; includeSubDomains"
-      - key: "X-Content-Type-Options"
-        value: "nosniff"
-      - key: "X-XSS-Protection"
-        value: "1; mode=block"
-      - key: "X-Frame-Options"
-        value: "DENY"
-      # CSP generated using Laboratory: https://github.com/april/laboratory
-      # Caveats
-      ## Stripe Elements adds inline JS and iFrame (unsafe-eval, frame-src)
-      ## Allows any endpoint hosted on AWS - for prod, use custom domains
-      ### REST and GraphQL have random identifiers so we allow the sub-domain (connect-src)
-      ### connect-src doesn't parse cognito-idp.*.amazonaws.com used by Amplify Auth - for prod, use region(s) endpoint
-      - key: "Content-Security-Policy"
-        value: "'default-src 'none'; connect-src https://*.amazonaws.com; font-src 'self' https://fonts.gstatic.com; frame-src https://js.stripe.com; img-src 'self'; script-src 'self' 'unsafe-eval' https://js.stripe.com/v3/; style-src 'self' https://fonts.googleapis.com/css?family=Raleway 'unsafe-inline' https://fonts.googleapis.com'"
+  customHeaders:
+    - pattern: "**/*"
+      headers: # https://infosec.mozilla.org/guidelines/web_security
+        - key: "Strict-Transport-Security"
+          value: "max-age=31536000; includeSubDomains"
+        - key: "X-Content-Type-Options"
+          value: "nosniff"
+        - key: "X-XSS-Protection"
+          value: "1; mode=block"
+        - key: "X-Frame-Options"
+          value: "DENY"
+        # CSP generated using Laboratory: https://github.com/april/laboratory
+        # Caveats
+        ## Stripe Elements adds inline JS and iFrame (unsafe-eval, frame-src)
+        ## Allows any endpoint hosted on AWS - for prod, use custom domains
+        ### REST and GraphQL have random identifiers so we allow the sub-domain (connect-src)
+        ### connect-src doesn't parse cognito-idp.*.amazonaws.com used by Amplify Auth - for prod, use region(s) endpoint
+        - key: "Content-Security-Policy"
+          value: "'default-src 'none'; connect-src https://*.amazonaws.com; font-src 'self' https://fonts.gstatic.com; frame-src https://js.stripe.com; img-src 'self'; script-src 'self' 'unsafe-eval' https://js.stripe.com/v3/; style-src 'self' https://fonts.googleapis.com/css?family=Raleway 'unsafe-inline' https://fonts.googleapis.com'"

--- a/amplify/backend/auth/cognitoa7d29d9d/cognitoa7d29d9d-cloudformation-template.yml
+++ b/amplify/backend/auth/cognitoa7d29d9d/cognitoa7d29d9d-cloudformation-template.yml
@@ -508,6 +508,20 @@ Resources:
     DependsOn: IdentityPool
   
 
+  StripePaymentApplicationAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties: 
+      PolicyName: StripePaymentApplicationAccessPolicy
+      PolicyDocument: 
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'execute-api:*'
+            Resource: "*" #  StripePaymentApplication SAR does not export API Gateway ARN ...
+      Roles:
+        - !Select [1, !Split ['/', !Ref authRoleArn]]
+
 Outputs :
   
   IdentityPoolId:

--- a/src/frontend/store/bookings/actions.js
+++ b/src/frontend/store/bookings/actions.js
@@ -2,13 +2,25 @@ import Booking from "../../shared/models/BookingClass";
 import Flight from "../../shared/models/FlightClass"; // eslint-disable-line
 // @ts-ignore
 import { Loading } from "quasar";
-import axios from "axios";
 
-import { API, graphqlOperation } from "aws-amplify";
+import Amplify, { API, graphqlOperation } from "aws-amplify";
 import {
   processBooking as processBookingMutation,
   getBookingByStatus
 } from "./graphql";
+
+const StripeChargeEndpointName = "StripeChargeEndpoint";
+
+const endpoints = {
+  API: {
+    endpoints: [
+      {
+        name: StripeChargeEndpointName,
+        endpoint: process.env.VUE_APP_PaymentChargeUrl || "no payment gateway endpoint set"
+      }
+    ]
+  }
+};
 
 /**
  *
@@ -122,15 +134,12 @@ export async function createBooking(
 ) {
   console.group("store/bookings/actions/createBooking");
   try {
-    let paymentEndpoint =
-      process.env.VUE_APP_PaymentChargeUrl || "no payment gateway endpoint set";
     const customerEmail = rootState.profile.user.attributes.email;
 
     console.info(
       `Processing payment before proceeding to booking for flight ${outboundFlight}`
     );
     let chargeToken = await processPayment({
-      endpoint: paymentEndpoint,
       paymentToken,
       outboundFlight,
       customerEmail
@@ -161,7 +170,6 @@ export async function createBooking(
  * Process Payment function - processPayment calls Payment endpoint to pre-authorize charge upon tokenized payment details
  *
  * @param {object} obj - Object containing params to process payment
- * @param {string} obj.endpoint - Payment endpoint
  * @param {object} obj.paymentToken - Tokenized payment info
  * @param {object} obj.paymentToken.details - Tokenized payment details including last4, id, etc.
  * @param {object} obj.paymentToken.id - Payment token
@@ -177,7 +185,6 @@ export async function createBooking(
  *   });
  */
 async function processPayment({
-  endpoint,
   paymentToken,
   outboundFlight,
   customerEmail
@@ -198,15 +205,12 @@ async function processPayment({
   };
 
   console.log("Charge data to be processed");
-  console.log(chargeData);
-  try {
-    const data = await axios.post(endpoint, chargeData);
-    const {
-      data: {
-        createdCharge: { id: chargeId }
-      }
-    } = data;
 
+  Amplify.configure({...endpoints});
+
+  try {
+    const data = await await API.post(StripeChargeEndpointName, "", {body: chargeData});
+    const chargeId = data.createdCharge.id;
     console.groupEnd();
     return chargeId;
   } catch (err) {


### PR DESCRIPTION
This PR brings 2 updates:

## Stripe public key
Strip public key used by frontend to get charge token was hard coded in .env and therefore potentially not matching the private API key set for the backend service.

This PR enable developer to set its own public key through env variable.

## Secure APIGW calls

currently stripe APIGW endpoint is open to the world, in order to be able to secure access to the endpoint, we need to send authenticated and signed requests. To ease this I propose to move to Amplify `API.post()`  API which will automatically add proper header and signature to the call.