### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/src/backend/loyalty/template.yaml
+++ b/src/backend/loyalty/template.yaml
@@ -59,7 +59,7 @@ Resources:
       FunctionName: !Sub Airline-IngestLoyalty-${Stage}
       CodeUri: build/ingest
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref LoyaltyDataTable
@@ -82,7 +82,7 @@ Resources:
       FunctionName: !Sub Airline-GetLoyalty-${Stage}
       CodeUri: build/get
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref LoyaltyDataTable


### PR DESCRIPTION
CloudFormation templates in aws-serverless-airline-booking have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.