### PR TITLE
chore: remove whitespace character to fix the deploy cmd

### DIFF
--- a/src/backend/payment/Makefile
+++ b/src/backend/payment/Makefile
@@ -43,7 +43,7 @@ deploy: ##=> Deploy payment service using SAM
 	$(info [*] Packaging and deploying Payment service...)
 	sam package \
 		--s3-bucket $${DEPLOYMENT_BUCKET_NAME} \
-		--output-template-file packaged.yaml && \ 
+		--output-template-file packaged.yaml && \
 	aws cloudformation deploy \
 		--template-file packaged.yaml \
 		--stack-name $${STACK_NAME}-payment-$${AWS_BRANCH} \


### PR DESCRIPTION
*Issue #, if available:* #128 

*Description of changes:*
Behold the worlds tinies pull request. This sneaky space character is killing the 1-click deployment,   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
