### PR TITLE
Update Loyalty API to deploy the Account CloudWatchRole that is required

### DIFF
--- a/src/backend/loyalty/template.yaml
+++ b/src/backend/loyalty/template.yaml
@@ -32,6 +32,29 @@ Parameters:
 
 
 Resources:
+  CloudWatchRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - >-
+          arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  
+  Account:
+    Type: 'AWS::ApiGateway::Account'
+    Properties:
+      CloudWatchRoleArn: !GetAtt 
+        - CloudWatchRole
+        - Arn
+
   LoyaltyDataTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/src/backend/loyalty/template.yaml
+++ b/src/backend/loyalty/template.yaml
@@ -32,29 +32,6 @@ Parameters:
 
 
 Resources:
-  CloudWatchRole:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - apigateway.amazonaws.com
-            Action: 'sts:AssumeRole'
-      Path: /
-      ManagedPolicyArns:
-        - >-
-          arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
-  
-  Account:
-    Type: 'AWS::ApiGateway::Account'
-    Properties:
-      CloudWatchRoleArn: !GetAtt 
-        - CloudWatchRole
-        - Arn
-
   LoyaltyDataTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -151,6 +128,31 @@ Resources:
       Type: String
       Value: !Sub "https://${LoyaltyApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
 
+  #
+  # Uncomment the following resources + AccessLogSetting to enable API Gateway Logs
+  # [CAUTION] API Gateway can only have one IAM Role to push logs too, do not uncomment if you already have one
+  # 
+  # ApiGatewayCloudWatchRole:
+  #   Type: 'AWS::IAM::Role'
+  #   Properties:
+  #     AssumeRolePolicyDocument:
+  #       Version: 2012-10-17
+  #       Statement:
+  #         - Effect: Allow
+  #           Principal:
+  #             Service:
+  #               - apigateway.amazonaws.com
+  #           Action: 'sts:AssumeRole'
+  #     Path: /
+  #     ManagedPolicyArns:
+  #       - >-
+  #         arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  #
+  # ApiGatewayCloudWatchLogsConfig:
+  #   Type: 'AWS::ApiGateway::Account'
+  #   Properties:
+  #     CloudWatchRoleArn: !GetAtt ApiGatewayCloudWatchRole.Arn
+
   LoyaltyApi:
     Type: AWS::Serverless::Api
     Properties:
@@ -161,9 +163,9 @@ Resources:
       #   AllowHeaders:
       #     "'Content-Type,Authorization,X-Amz-Date'"
       #   MaxAge: "'600'"
-      AccessLogSetting:
-        DestinationArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LoyaltyApiLogGroup}"
-        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "error": "$context.error.message", "user_arn": "$context.identity.userArn"}'
+      # AccessLogSetting:
+      #   DestinationArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LoyaltyApiLogGroup}"
+      #   Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "caller":"$context.identity.caller", "user":"$context.identity.user","requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "error": "$context.error.message", "user_arn": "$context.identity.userArn"}'
       MethodSettings:
         - MetricsEnabled: True
           ResourcePath: "/*"


### PR DESCRIPTION
*Issue #, if available:*
#128

*Description of changes:*
I ran into the same issue described in #128.  

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-account.html holds the answer to fix this programatically and in a region agnostic way.

FYI - There seems to be some fragility with the order of operations here:
![image](https://user-images.githubusercontent.com/583660/94289397-a9278100-ff26-11ea-8312-eab8d7b04e62.png)

I haven't tested on a clean AWS account, but given that Payments API deploys clean, I think this fix will work (I'm not a SAM expert and am coming from another cloud provider so troubleshooting this has been quite the learning experience!)

Note: if you're in the state described in #128, you will need to manually go into the CloudFormation Console and delete the stack stuck in `ROLLBACK_COMPLETE` or you will get an error like this one: 
  - ![image](https://user-images.githubusercontent.com/583660/94287146-f0604280-ff23-11ea-83c7-bc19e9d44d73.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
