### PR TITLE
[Perf Stack] - fixing the deploy targets

### DIFF
--- a/src/perf-tests/Makefile
+++ b/src/perf-tests/Makefile
@@ -1,4 +1,4 @@
-deploy.perftest: ##=> Deploying Gatling components for performance testing
+deploy: ##=> Deploying Gatling components for performance testing
 	$(info [*] Deploying Gatling components for performance testing ...)
 	cd perftest-stack-airline && \
 		npm install && \
@@ -7,5 +7,5 @@ deploy.perftest: ##=> Deploying Gatling components for performance testing
 		cdk bootstrap && \
 		cdk deploy $${PERF_TEST_STACK_NAME} --require-approval never
 
-delete.perftest: ##=> Delete performance testing stack
+delete: ##=> Delete performance testing stack
 	cdk destroy $${PERF_TEST_STACK_NAME}


### PR DESCRIPTION
*Issue #, if available:* #131 

*Description of changes:*

The [MakeFile](https://github.com/aws-samples/aws-serverless-airline-booking/blob/develop/src/perf-tests/Makefile) is missing the deploy method.

Fix:
- Change deploy.perftest to deploy in the src/perf-tests/Makefile
- Change delete.perftest to delete in the src/perf-tests/Makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
