### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/auth/awsserverlessairline44ea6421/awsserverlessairline44ea6421-cloudformation-template.yml
+++ b/amplify/backend/auth/awsserverlessairline44ea6421/awsserverlessairline44ea6421-cloudformation-template.yml
@@ -232,7 +232,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/src/backend/loyalty/template.yaml
+++ b/src/backend/loyalty/template.yaml
@@ -59,7 +59,7 @@ Resources:
       FunctionName: !Sub Airline-IngestLoyalty-${Stage}
       CodeUri: build/ingest
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref LoyaltyDataTable
@@ -87,7 +87,7 @@ Resources:
       FunctionName: !Sub Airline-GetLoyalty-${Stage}
       CodeUri: build/get
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref LoyaltyDataTable


### PR DESCRIPTION
CloudFormation templates in aws-serverless-airline-booking have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.